### PR TITLE
autocomplete mouse click issue

### DIFF
--- a/fa/jquery/jquery-ui/fa/jquery.formalchemy.js
+++ b/fa/jquery/jquery-ui/fa/jquery.formalchemy.js
@@ -108,7 +108,6 @@ $.fa.extend({
   autocomplete: function(field, plugin, options) {
     options['select'] = function(event, ui) {
         field.val(ui.item.value);
-        return false;
     }
     var auto = $('<input autocomplete="off" value="" />');
     auto.val(field.val());


### PR DESCRIPTION
Removing return false in autocomplete select since it prevents the user from selecting an item using a mouse click
