### PR TITLE
update changes.txt + pyramid 1.1+ compatibility

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,9 @@
+0.9.5 - 2011-09-15
+------------------
+
+Add Pyramid 1.1 compatibility [amleczko]
+
+
 0.9.2
 -----
 

--- a/fa/jquery/__init__.py
+++ b/fa/jquery/__init__.py
@@ -45,7 +45,6 @@ def includeme(config):
         to_override="pyramid_formalchemy:templates/forms/",
         override_with="fa.jquery:templates/forms/")
 
-    config.add_route('markup_parser', '/markup_parser.html',
-                      view='fa.jquery.pyramid.markup_parser',
-                     )
+    config.add_route('markup_parser', '/markup_parser.html')
+    config.add_view('fa.jquery.pyramid.markup_parser', route_name='markup_parser')
     config.scan("fa.jquery.pyramid")

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '0.9.3'
+version = '0.9.5'
 
 long_description = open("README.txt").read()
 long_description += """


### PR DESCRIPTION
I think we need to start using version properly. On pypi lastest released is fa.jquery 0.9.4 (in changes.txt latest information is about 0.9.2). Can we try to update it and plan next release?
