### PR TITLE
make uiadmin css publicly available from module fanstatic_resources

### DIFF
--- a/fa/jquery/fanstatic_resources.py
+++ b/fa/jquery/fanstatic_resources.py
@@ -18,6 +18,7 @@ def R(path, *args, **kwargs):
         kwargs['minified'] = 'min/%s' % path
     return Resource(fa_library, path, *args, **kwargs)
 
+fa_uiadmin_css = R("jquery.formalchemy.uiadmin.css")
 fa_css = R("jquery.formalchemy.css")
 fa_js = R("jquery.formalchemy.js",
           depends=[jquery, jqueryui, jqueryui_i18n])
@@ -35,9 +36,8 @@ markitup_textile_set = R("markitup_sets/textile/set.js",
 
 jquery_tinymce = R("jquery.tinymce.js", depends=[tinymce, jquery])
 
-fa_jqgrid = R('fa.jqgrid.js',
-              depends=[jqgrid, fa_js])
+fa_jqgrid = R('fa.jqgrid.js', depends=[jqgrid, fa_js])
 
 fa = Group([fa_css, fa_js])
-fa_admin = Group([R("jquery.formalchemy.uiadmin.css"), fa_css, fa_js, selectmenu])
+fa_admin = Group([fa_uiadmin_css, fa_css, fa_js, selectmenu])
 


### PR DESCRIPTION
this commit fix the issue that I tried to explained on irc as follow:

the problem is that I need to specify that this css resource depends on fa.jquery css fanstatic resource
 but currently the fanstatic resources available in fa/jquery/fanstatic_resources.py are not all public
 for exemple I need to depends on R("jquery.formalchemy.uiadmin.css")
 which there is no reference set in the module
 this resource is instantiated directly in the Group:
 fa_admin = Group([R("jquery.formalchemy.uiadmin.css"), fa_css, fa_js, selectmenu])
 I can make a pull request to have a reference to R("jquery.formalchemy.uiadmin.css") in the fanstatic_resources module
 but I think it should be clearly stated that resources available from fanstatic_resources are part of the api
 so that we'll have to update our code only when api compatibility is dropped
 or if resources available in fanstatic_resources are not part of the api, fa.jquery should provide a similar api to retrieve fanstatic resources that our own fanstatic resources can depend on
