### PR TITLE
Set dev version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '0.9.3'
+version = '0.9.5dev'
 
 long_description = open("README.txt").read()
 long_description += """


### PR DESCRIPTION
Set version to 0.9.5dev since current release is 0.9.4.
When working with buildout and fa.jquery trunk as a develop-eggs, we need this version to be bumped otherwise buildout will not see the fa.jquery clone as most recent version.
