### PR TITLE
expand filtering options

### DIFF
--- a/fa/jquery/pyramid/__init__.py
+++ b/fa/jquery/pyramid/__init__.py
@@ -78,7 +78,7 @@ class ModelView(Base):
                     if op == 'cn':
                         value = '%%%s%%' % value
                         filter = field.ilike(value)
-                    else if op == 'ne':
+                    elif op == 'ne':
                         filter = field!=value
                     else:
                         filter = field==value

--- a/fa/jquery/pyramid/__init__.py
+++ b/fa/jquery/pyramid/__init__.py
@@ -78,6 +78,8 @@ class ModelView(Base):
                     if op == 'cn':
                         value = '%%%s%%' % value
                         filter = field.ilike(value)
+                    else if op == 'ne':
+                        filter = field!=value
                     else:
                         filter = field==value
                     collection = collection.filter(filter)

--- a/fa/jquery/pyramid/__init__.py
+++ b/fa/jquery/pyramid/__init__.py
@@ -114,6 +114,7 @@ class ModelView(Base):
         for field in grid.render_fields.values():
             metadata = dict(search=0, sortable=1, id=field.key, name=field.key)
             searchoptions = dict(sopt=['eq', 'cn'])
+            limitedsearch = False
             if field.is_relation:
                 metadata.update(width=100, sortable=0)
             elif isinstance(field.type, (utils.Color, utils.Slider)):
@@ -125,10 +126,18 @@ class ModelView(Base):
                 metadata.update(search=1)
             elif isinstance(field.type, (fatypes.Date, fatypes.Integer)):
                 metadata.update(width=70, align='center')
+                metadata.update(search=1)
+                limitedsearch = True
             elif isinstance(field.type, fatypes.DateTime):
                 metadata.update(width=120, align='center')
+                metadata.update(search=1)
+                limitedsearch = True
             elif isinstance(field.type, fatypes.Boolean):
                 metadata.update(width=30, align='center')
+                metadata.update(search=1)
+                limitedsearch = True
+            if limitedsearch:
+                searchoptions = dict(sopt=['eq'])
             if metadata['search']:
                 metadata['searchoptions'] = searchoptions
             metadata = dict(json=dumps(metadata))

--- a/fa/jquery/pyramid/__init__.py
+++ b/fa/jquery/pyramid/__init__.py
@@ -113,7 +113,7 @@ class ModelView(Base):
         metadatas = ('width', 'align', 'fixed', 'search', 'stype', 'searchoptions')
         for field in grid.render_fields.values():
             metadata = dict(search=0, sortable=1, id=field.key, name=field.key)
-            searchoptions = dict(sopt=['eq', 'cn'])
+            searchoptions = dict(sopt=['eq', 'ne', 'cn'])
             limitedsearch = False
             if field.is_relation:
                 metadata.update(width=100, sortable=0)
@@ -137,7 +137,7 @@ class ModelView(Base):
                 metadata.update(search=1)
                 limitedsearch = True
             if limitedsearch:
-                searchoptions = dict(sopt=['eq'])
+                searchoptions = dict(sopt=['eq', 'ne'])
             if metadata['search']:
                 metadata['searchoptions'] = searchoptions
             metadata = dict(json=dumps(metadata))

--- a/fa/jquery/resources/fa.jqgrid.js
+++ b/fa/jquery/resources/fa.jqgrid.js
@@ -31,7 +31,7 @@ $.fa.extend({
         options['pager_id'] = '#'+pager.attr('id');
         table.jqGrid(settings);
         table.jqGrid('navGrid', options.pager_id,
-                     {search:true}); 
+                     {search:true}, {},{},{},{multipleSearch:true}); 
         $('#add_'+table.attr('id'))
             .unbind('click')
             .click(function() { editRow(); });

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '0.9.5-bluej100'
+version = '0.9.5'
 
 long_description = open("README.txt").read()
 long_description += """

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '0.9.5'
+version = '0.9.5-bluej100'
 
 long_description = open("README.txt").read()
 long_description += """


### PR DESCRIPTION
I realize that enabling filtering on more than just strings opens the door to bad user experience (alternative date formats, unintuitive booleans, etc.), but I think that the perfect is the enemy of the good here. This patch allows for filtering by equals and not-equals on virtually all columns, plus contains on strings.
